### PR TITLE
✏️ Normalize community wording and audit example

### DIFF
--- a/additional-support/faq.md
+++ b/additional-support/faq.md
@@ -72,7 +72,7 @@ You can find step-by-step submission instructions for each program here in the h
 
 <summary>Who reviews projects and votes for project allocation?</summary>
 
-* Projects are reviewed by a rotating delegate panel made up of SDF employees and trusted Stellar Community members. Anyone can become an SCF Delegate Panelist by earning the Pilot Role, which represents a significant commitment to the Stellar Ecosystem and to the Stellar Community Fund.
+* Projects are reviewed by a rotating delegate panel made up of SDF employees and trusted Stellar community members. Anyone can become an SCF Delegate Panelist by earning the Pilot Role, which represents a significant commitment to the Stellar Ecosystem and to the Stellar Community Fund.
 * SCF operates using a verified member system where individuals unlock different abilities as they move through the tiers. SCF Pathfinders are eligible to participate in Community Vote by delegating their votes to trusted delegates. SCF Navigators are able to vote directly for projects. SCF Pilots can vote directly for projects, and nominate themselves to be part of the Delegate Panel. Delegates carry the heaviest voting weight, based on delegation and quorum
 
 </details>
@@ -186,7 +186,7 @@ Any such follow-on awards may also require additional legal and business due dil
 
 <summary>How can I connect with other applicants and community members?</summary>
 
-Join the [Stellar Developers Discord Server](https://discord.gg/stellardev) to connect with other folks in the Stellar Community. This is a great way to ask project-specific questions, find partners to collaborate with, and get feedback prior to submitting.
+Join the [Stellar Developers Discord Server](https://discord.gg/stellardev) to connect with other folks in the Stellar community. This is a great way to ask project-specific questions, find partners to collaborate with, and get feedback prior to submitting.
 
 </details>
 

--- a/additional-support/history-of-scf.md
+++ b/additional-support/history-of-scf.md
@@ -341,7 +341,7 @@ As SCF evolves, the goal remains the same: to be the most effective launch mecha
 SCF is ever evolving, and new structure ideas and additions are under active discussion. You’re invited to participate! Join the[ Stellar Developers Discord](http://discord.gg/stellardev) (and make sure you’re opting in for the Community Fund role) and become[ SCF verified](https://stellarcommunityfund.gitbook.io/scf-handbook/community-involvement/governance/how-to-become-verified).
 
 {% hint style="info" %}
-If you've been part of the Stellar Community for a while and some of what is documented here seems inaccurate, let us know through the [Stellar Developers Discord ](https://discord.gg/stellardev)or email us at communityfund@stellar.org. We strive to have a complete, candid, and transparent historic overview we can learn from as we work on future iterations of SCF.&#x20;
+If you've been part of the Stellar community for a while and some of what is documented here seems inaccurate, let us know through the [Stellar Developers Discord ](https://discord.gg/stellardev)or email us at communityfund@stellar.org. We strive to have a complete, candid, and transparent historic overview we can learn from as we work on future iterations of SCF.&#x20;
 {% endhint %}
 
 [^1]: 

--- a/scf-awards/build-award/README.md
+++ b/scf-awards/build-award/README.md
@@ -128,7 +128,7 @@ You are responsible for safeguarding your own private keys and wallet. SCF/SDF h
 
 ### SCF Build Referral Program
 
-The Stellar Community Fund relies heavily on signals from vetted referral sources for project support. If you’ve been in touch with someone in the Stellar Community, an SDF employee, or a partner, make sure to ask them for their unique referrer code, and include it in your interest form. This helps the SCF team to narrow focus and provide high-touch support to high-quality teams.
+The Stellar Community Fund relies heavily on signals from vetted referral sources for project support. If you’ve been in touch with someone in the Stellar community, an SDF employee, or a partner, make sure to ask them for their unique referrer code, and include it in your interest form. This helps the SCF team to narrow focus and provide high-touch support to high-quality teams.
 
 [SCF Referral Program Terms & Conditions](referral-program.md)<br>
 

--- a/supporting-programs/audit-bank/official-rules.md
+++ b/supporting-programs/audit-bank/official-rules.md
@@ -135,7 +135,7 @@ Example 1: A financial protocol managing $500K TVL would qualify for an audit du
 {% endhint %}
 
 {% hint style="info" %}
-Example 2: An escrow account project with <$100K TVL would qualify only after surpassing the $100K TVL threshold for non-priority categories and receiving review panel approval based on a valid justification (e.g., without an audit, a breach or vulnerability in the project could have medium- or high-severity consequences and result in the loss of user funds).
+Example 2: An escrow account project with <$100K TVL would qualify only after reaching the $100K TVL threshold for non-priority categories and receiving review panel approval based on a valid justification (e.g., without an audit, a breach or vulnerability in the project could have medium- or high-severity consequences and result in the loss of user funds).
 {% endhint %}
 
 ### General Rules

--- a/supporting-programs/audit-bank/official-rules.md
+++ b/supporting-programs/audit-bank/official-rules.md
@@ -135,7 +135,7 @@ Example 1: A financial protocol managing $500K TVL would qualify for an audit du
 {% endhint %}
 
 {% hint style="info" %}
-Example 2: An escrow account project with <$100K TVL would only qualify once it surpasses the $100K TVL threshold for non-priority categories, and there is a by the review panel-accepted reason to do so (e.g. this project is adopting a use case where the consequence of a breach or vulnerabilities can be medium or high without audit, and would result in the loss of user funds)
+Example 2: An escrow account project with <$100K TVL would qualify only after surpassing the $100K TVL threshold for non-priority categories and receiving review panel approval based on a valid justification (e.g., without an audit, a breach or vulnerability in the project could have medium- or high-severity consequences and result in the loss of user funds).
 {% endhint %}
 
 ### General Rules


### PR DESCRIPTION
It is [best practice](https://cdn.sanity.io/files/e2r40yh6/production-i18n/3755e548a02b9c26c9cca9b30021fc3fdd43e20b.pdf#page=84) to keep modifiers of the `Stellar` name lowercase, like in https://github.com/stellar/stellar-protocol/pull/1910. This PR makes an adjustment to such references to the community, a common noun representing a broad group of people. It also fixes wording in a community grant example, which previously used unclear and run-on phrasing.