### PR TITLE
📝 Move punctuation outside links

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ _July 2026_
 
 _April 2026_
 
-* Estimated development time for each partner added to [integration track list,](scf-awards/build-award/integration-track/integration-list.md) with more info [here.](https://airtable.com/appymB1sbp5uidiGe/shrQFLSRUqxI7tBdT) Teams should use these to scope their budgets appropriately, and delegates will cross-reference them when reviewing
+* Estimated development time for each partner added to [integration track list](scf-awards/build-award/integration-track/integration-list.md), with more info [here](https://airtable.com/appymB1sbp5uidiGe/shrQFLSRUqxI7tBdT). Teams should use these to scope their budgets appropriately, and delegates will cross-reference them when reviewing
 * Additional guidelines added around "what makes a strong Open Track submission" section.
 * Additional guidelines and requirements added for [RFP submissions](scf-awards/build-award/rfp-track.md).
 * RFP track delegates agreed to push Q2 RFPs to SCF #44. There will be no open RFPs for the SCF #43 submission window.

--- a/additional-support/faq.md
+++ b/additional-support/faq.md
@@ -20,7 +20,7 @@ SCF is the Stellar Community Fund - an open-application awards program that leve
 
 <summary>Who is eligible to apply for SCF?</summary>
 
-SCF has a [number of programs](https://app.gitbook.com/s/4IGHJeoWQzABoSBkKBxt/scf-awards) meant for projects at many stages of development, but generally, the SCF Build Award is for teams with significant existing traction. As a general rule, all projects should be building on Stellar, and should not fall within [ineligible criteria. ](../scf-awards/official-rules-for-submissions.md#general-rules)Individuals, Teams of Individuals, and Entities are all encouraged to submit for SCF.
+SCF has a [number of programs](https://app.gitbook.com/s/4IGHJeoWQzABoSBkKBxt/scf-awards) meant for projects at many stages of development, but generally, the SCF Build Award is for teams with significant existing traction. As a general rule, all projects should be building on Stellar, and should not fall within [ineligible criteria](../scf-awards/official-rules-for-submissions.md#general-rules). Individuals, Teams of Individuals, and Entities are all encouraged to submit for SCF.
 
 </details>
 
@@ -105,7 +105,7 @@ Short answer: yes. Long answer: most projects will begin in one of the three ava
 
 <summary><strong>What are the evaluation criteria for applications?</strong></summary>
 
-General application criteria can be found [here](../scf-awards/build-award/submission-criteria.md)[.](../scf-awards/official-rules-for-submissions.md)
+General application criteria can be found [here](../scf-awards/build-award/submission-criteria.md).
 
 </details>
 
@@ -146,7 +146,7 @@ General application criteria can be found [here](../scf-awards/build-award/submi
 
 <summary>What are the reporting requirements if my project is funded?</summary>
 
-The [SCF Build Award](../scf-awards/build-award/) is split into 4 total tranches of funding, so you will need to report back on your progress in order to receive your total budget. You can find more information on this in the [SCF Build section of the handbook.](../scf-awards/build-award/)
+The [SCF Build Award](../scf-awards/build-award/) is split into 4 total tranches of funding, so you will need to report back on your progress in order to receive your total budget. You can find more information on this in the [SCF Build section of the handbook](../scf-awards/build-award/).
 
 </details>
 
@@ -162,7 +162,7 @@ We understand that unforeseen circumstances can sometimes affect a project's pro
 
 <summary>Are there any restrictions on how the funding can be used?</summary>
 
-The different SCF programs have different requirements for funding, so be sure you carefully review program-specific guidelines before submitting. General guidelines for all projects can be found [here.](../scf-awards/official-rules-for-submissions.md)
+The different SCF programs have different requirements for funding, so be sure you carefully review program-specific guidelines before submitting. General guidelines for all projects can be found [here](../scf-awards/official-rules-for-submissions.md).
 
 </details>
 
@@ -223,7 +223,7 @@ For more information on how this would work for tiers, [click here](../governanc
 
 <summary>How can I get more involved with SCF from a governance and structure perspective?</summary>
 
-You can start by getting verified as a community member [here.](https://communityfund.stellar.org/tiers) As you move up the tiers, more opportunities become available to you, including participating in Community Vote, influencing future SCF structure changes, and serving on Category-Specific Delegate Panels.
+You can start by getting verified as a community member [here](https://communityfund.stellar.org/tiers). As you move up the tiers, more opportunities become available to you, including participating in Community Vote, influencing future SCF structure changes, and serving on Category-Specific Delegate Panels.
 
 </details>
 
@@ -233,7 +233,7 @@ You can start by getting verified as a community member [here.](https://communit
 
 <summary>Where can I find resources to help with my application?</summary>
 
-This handbook provides the most up-to-date information about category-specific eligibility, program structure, and program guidelines. More information (including past SCF Awardees) can be found on the [SCF Website.](https://communityfund.stellar.org/)
+This handbook provides the most up-to-date information about category-specific eligibility, program structure, and program guidelines. More information (including past SCF Awardees) can be found on the [SCF Website](https://communityfund.stellar.org/).
 
 </details>
 

--- a/scf-awards/build-award/README.md
+++ b/scf-awards/build-award/README.md
@@ -50,7 +50,7 @@ If you're looking to fund development and launch of a usable application or prot
 1. **Submit the interest form on the SCF Website**\
    Go to [communityfund.stellar.org](http://communityfund.stellar.org) and tell us a little about what you’re building in the interest form. This is where you’ll tell us what Build Award track you’re interested in, and if you were referred by someone from the Stellar community. These inquiries are reviewed on a rolling basis. If you meet requirements, you will be invited to submit to an open SCF round and given the round deadline via email. If you want to ensure you’re considered to be a part of a specific round, get your interest form in as soon as possible.<br>
 2. **Referral Confirmation and Eligibility Review**\
-   SCF relies heavily on signals from our referrers to determine eligibility. If you listed an SCF referrer, they’ll be asked to confirm that referral and to provide any relevant context about your project. Though a referral is not mandatory to receive an SCF award, SCF relies heavily on referral signals. [Learn more about the referral program here.](./#scf-build-referral-program)\
+   SCF relies heavily on signals from our referrers to determine eligibility. If you listed an SCF referrer, they’ll be asked to confirm that referral and to provide any relevant context about your project. Though a referral is not mandatory to receive an SCF award, SCF relies heavily on referral signals. [Learn more about the referral program here](./#scf-build-referral-program).\
    \
    If you don’t have an SCF referrer, your project will still go through an initial review to determine if you’re currently eligible to submit to SCF.<br>
 3. **Invited to submit to SCF Build**\

--- a/scf-awards/build-award/integration-track/integration-list.md
+++ b/scf-awards/build-award/integration-track/integration-list.md
@@ -6,7 +6,7 @@ description: 'SCF Build Integration Track: Current Integration List'
 
 For your SCF Build Integration Track submission, you’ll need to choose at least one of the building blocks on this list. This list does not represent an exhaustive list of the protocols, wallets, anchors, etc. available on Stellar, but the building blocks on it have been tested and recommended by the community, and offer thorough docs and tutorials to help you integrate. This list was recommended by Pilots in the SCF Community, and is re-evaluated quarterly.
 
-Note: Most of your requested budget should go towards the costs associated with your chosen integration(s). Estimated integration time is provided to help you scope your submission. You can find more information from the teams about integration times [here.](https://airtable.com/appymB1sbp5uidiGe/shrQFLSRUqxI7tBdT)
+Note: Most of your requested budget should go towards the costs associated with your chosen integration(s). Estimated integration time is provided to help you scope your submission. You can find more information from the teams about integration times [here](https://airtable.com/appymB1sbp5uidiGe/shrQFLSRUqxI7tBdT).
 
 ***
 


### PR DESCRIPTION
From #3

Punctuation shouldn't be in hyperlinks ([src](https://developers.google.com/style/cross-references#punctuation))